### PR TITLE
Support importing dividends

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Sync your Ghostfolio with IBKR
 * Account Information: Currency
 * Cash Report: Currency, Ending Cash
 * Trades: Select All (however there is a risk new IBKR fields will cause issues)
+For dividends, also include:
+* Change in Dividend Accruals: Quantity, Gross Rate, Action ID, Currency, Symbol, ISIN, FIGI, Date, Fee, Code
 
 Follow this guide to configure your Flex Queries in your Interactive Brokers account:
 [https://portfellow.com/how-to-configure-ib-import](https://portfellow.com/how-to-configure-ib-import)


### PR DESCRIPTION
## Summary by Sourcery

Add support for importing dividend cash payments from IBKR statements into activities and document the required Flex Query fields.

New Features:
- Import dividend cash payments from IBKR Change in Dividend Accruals into the activities list as DIVIDEND entries.

Enhancements:
- Extend symbol resolution to handle both trade and dividend accrual records.

Documentation:
- Update README with instructions on including Change in Dividend Accruals fields in the IBKR Flex Query for dividend support.