### PR TITLE
feat: filter OPTION trade

### DIFF
--- a/SyncIBKR.py
+++ b/SyncIBKR.py
@@ -177,6 +177,9 @@ class SyncIBKR:
                     logger.info("trade is not buy or sell (ignoring): %s", trade)
                     continue
 
+                if trade.assetCategory == enums.AssetClass.OPTION:
+                    continue
+
                 activities.append({
                     "accountId": account_id,
                     "comment": f"tradeID={trade.tradeID}",


### PR DESCRIPTION
Ghostfolio does not support options. This change skips IBKR trades with assetCategory = OPT so sync does not fail on mixed stock/option portfolios.

## Summary by Sourcery

Bug Fixes:
- Prevent sync failures by ignoring IBKR trades with assetCategory marked as options (OPT).